### PR TITLE
Emit error event when error is passed to callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ function request() {
 `q = Queue(callback, concurrency)`
 
 `callback` is the function that this queue runs. Concurrency is how
-many simultaneous jobs should run of that function.
+many simultaneous jobs should run of that function. `callback` will receive `object` and
+`callback` as arguments. If `callback` is a call with an error as a first
+argument, the queue will emit an error event.
 
 `q.add()`
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ Queue.prototype.invoke = function() {
 };
 
 Queue.prototype.next = function(err) {
+    if (err) this.emit('error', err);
     if (this.queue.length) {
         process.nextTick(this.invoke);
     } else {

--- a/test/queue.js
+++ b/test/queue.js
@@ -26,4 +26,13 @@ describe('queue', function() {
             q.add('foo');
         });
     });
+    describe('on error', function() {
+        it('should be invoked when task passes an err into callback', function(done) {
+            var q = new Queue(function(obj, callback) { callback(new Error('dummy')) }, 3);
+            q.on('error', function() {
+                done();
+            });
+            q.add('foo');
+        });
+    });
 });


### PR DESCRIPTION
This will require applications listen to `error` events to avoid uncaught error exceptions.
